### PR TITLE
Change the testbook YAML link from branch e2e-test-setup to master

### DIFF
--- a/testdata/testcases/release-operator-e2e.json
+++ b/testdata/testcases/release-operator-e2e.json
@@ -2,7 +2,7 @@
 {
   "test_id": "release-001",
   "desc": "helmrelease install test: guestbook deploy",
-  "urls": ["https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/e2e-test-setup/examples/test-guestbook010.yaml"],
+  "urls": ["https://raw.githubusercontent.com/open-cluster-management/multicloud-operators-subscription-release/master/examples/test-guestbook010.yaml"],
   "target_cluster": "hub"
 }
 ]


### PR DESCRIPTION
Change this link as the e2e-test-setup is deleted. We should use master branch link instead.