### PR TITLE
In argocd canary test, just validate application deployment created i…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN  microdnf update -y \
         && microdnf install openssh-clients \
         && microdnf install golang \
         && microdnf install curl \
+        && microdnf install procps \
         && microdnf install tar \
         && microdnf clean all
 


### PR DESCRIPTION
…n spoke cluster

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

Two fixes:

1. add `ps` tool into the image

2. ArgoCD canary test should be regarded as successful as long as the ArgoCD guestbook application deployment resource is created in the spoke cluster. 

We noticed sometimes the guestbook-ui pod failed to start in canary spoke cluster though its deployment is there.  That should be an env issue in canary spoke cluster.