### PR TITLE
The latest argocd has changed the way to get the initial password

### DIFF
--- a/client/canary/scripts/argocd_integration.sh
+++ b/client/canary/scripts/argocd_integration.sh
@@ -113,7 +113,7 @@ fi
 chmod +x /usr/local/bin/argocd
 
 # login using the cli
-ARGOCD_PWD=$($KUBECTL_HUB get pods -n argocd -l app.kubernetes.io/name=argocd-server -o name | cut -d'/' -f 2)
+ARGOCD_PWD=$($KUBECTL_HUB -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
 ARGOCD_HOST="localhost:8080"
 
 echo "argocd login $ARGOCD_HOST --insecure --username admin --password $ARGOCD_PWD"


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The argocd just released v2.0.0 as its latest version, where the initial password has been changed. That caused the canary test failure

https://github.com/open-cluster-management/backlog/issues/8659