### PR TITLE
Only detect local-cluster secret to be imported to different argocd s…

### DIFF
--- a/client/canary/scripts/gitopscluster_test.sh
+++ b/client/canary/scripts/gitopscluster_test.sh
@@ -299,7 +299,7 @@ $KUBECTL_HUB apply -f scripts/argocd/managedclusterset.yaml
 echo "$(date) managedclusterset created"
 
 # Add all managed clusters to managedclusterset clusterset1
-MANAGED_CLUSTERS=( $($KUBECTL_HUB get managedclusters -o name |awk -F/ '{print $2}') )
+MANAGED_CLUSTERS=( $($KUBECTL_HUB get managedclusters -l local-cluster=true -o name |awk -F/ '{print $2}') )
 
 for element in "${MANAGED_CLUSTERS[@]}"
 do


### PR DESCRIPTION
…erver NS

Signed-off-by: Xiangjing Li <xiangli@redhat.com>

It turns out there are various kinds of non-ocp K8s clusters imported into Canary test env like Azure, GKE etc. Non OCP clusters don't have the cluster secrets generated. 

The fix is detect local-cluster secret to be imported to different argocd server NameSpaces based on the gitopscluster CR spec changes.  local-cluster is OCP cluster for sure.
